### PR TITLE
Basic Auth

### DIFF
--- a/ping/decorators.py
+++ b/ping/decorators.py
@@ -8,6 +8,16 @@ from django.conf import settings
 from ping.defaults import PING_BASIC_AUTH
 
 def http_basic_auth(func):
+    """
+    Attempts to login user with u/p provided in HTTP_AUTHORIZATION header.
+    If successful, returns the view, otherwise returns a 401.
+    If PING_BASIC_AUTH is False, then just return the view function 
+    
+    Modified code by:
+    http://djangosnippets.org/users/bthomas/
+    from
+    http://djangosnippets.org/snippets/1304/
+    """
     @wraps(func)
     def _decorator(request, *args, **kwargs):
         if getattr(settings, 'PING_BASIC_AUTH', PING_BASIC_AUTH):

--- a/ping/decorators.py
+++ b/ping/decorators.py
@@ -1,0 +1,30 @@
+from functools import wraps
+import base64
+
+from django.http import HttpResponse
+from django.contrib.auth import authenticate, login
+from django.conf import settings
+
+from ping.defaults import PING_BASIC_AUTH
+
+def http_basic_auth(func):
+    @wraps(func)
+    def _decorator(request, *args, **kwargs):
+        if getattr(settings, 'PING_BASIC_AUTH', PING_BASIC_AUTH):
+            from django.contrib.auth import authenticate, login
+            if request.META.has_key('HTTP_AUTHORIZATION'):
+                authmeth, auth = request.META['HTTP_AUTHORIZATION'].split(' ', 1)
+                if authmeth.lower() == 'basic':
+                    auth = auth.strip().decode('base64')
+                    username, password = auth.split(':', 1)
+                    user = authenticate(username=username, password=password)
+                    if user:
+                        login(request, user)
+                        return func(request, *args, **kwargs)
+                    else:
+                        return HttpResponse("Invalid Credentials", status=401)
+            else:
+                return HttpResponse("No Credentials Provided", status=401)
+        else:
+            return func(request, *args, **kwargs)
+    return _decorator

--- a/ping/defaults.py
+++ b/ping/defaults.py
@@ -5,3 +5,5 @@ PING_DEFAULT_CHECKS = (
     'ping.checks.check_database_sessions',
     'ping.checks.check_database_sites',
 )
+
+PING_BASIC_AUTH = False

--- a/ping/views.py
+++ b/ping/views.py
@@ -1,16 +1,18 @@
 from django.http import HttpResponse
 from django.conf import settings
 from django.utils import simplejson
+from django.contrib.auth.decorators import login_required
 
 from ping.defaults import *
 from ping.checks import checks
+from ping.decorators import http_basic_auth
 
-
+@http_basic_auth
 def status(request):
     """
     Returns a simple HttpResponse
     """
-    
+        
     response = "<h1>%s</h1>" % getattr(settings, 'PING_DEFAULT_RESPONSE', PING_DEFAULT_RESPONSE)
     mimetype = getattr(settings, 'PING_DEFAULT_MIMETYPE', PING_DEFAULT_MIMETYPE)
     
@@ -23,6 +25,11 @@ def status(request):
         response += "</dl>"
 
     if request.GET.get('fmt') == 'json':
+        try:
+            response = simplejson.dumps(response_dict)
+        except UnboundLocalError:
+            response_dict = checks(request)
+            response = simplejson.dumps(response_dict)
         response = simplejson.dumps(response_dict)
         mimetype = 'application/json'  
 


### PR DESCRIPTION
Basic http auth can be required by setting PING_BASIC_AUTH to True in django settings.  Provide the credentials of a valid django user.
