### PR TITLE
Sort status checks (using develop branch)

### DIFF
--- a/ping/views.py
+++ b/ping/views.py
@@ -21,7 +21,7 @@ def status(request):
     if request.GET.get('checks') == 'true':
         response_dict = checks(request)
         response += "<dl>"
-        for key, value in response_dict.items():
+        for key, value in sorted(response_dict.items()):
             response += "<dt>%s</dt>" % str(key)
             response += "<dd>%s</dd>" % str(value)
         response += "</dl>"
@@ -32,7 +32,7 @@ def status(request):
         except UnboundLocalError:
             response_dict = checks(request)
             response = simplejson.dumps(response_dict)
-        response = simplejson.dumps(response_dict)
+        response = simplejson.dumps(response_dict, sort_keys=True)
         mimetype = 'application/json'  
 
     return HttpResponse(response, mimetype=mimetype, status=200)


### PR DESCRIPTION
(As requested, I'm resubmitting this patch using the develop branch.)

If a monitoring service is looking for a specific string to be
present in the response from /ping to test if the Web site is
up and running, then consistent, sorted status check results are
necessary to avoid false positives.
