### PR TITLE
Combine the `rizmu` and `develop` branches - fixes Django 1.9 support

### DIFF
--- a/ping/checks.py
+++ b/ping/checks.py
@@ -1,5 +1,6 @@
+from importlib import import_module
+
 from django.conf import settings
-from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 
 from ping.defaults import *
@@ -11,7 +12,7 @@ def checks(request):
     for that check.
     """
     response_dict = {}
-    
+
     #Taken straight from Django
     #If there is a better way, I don't know it
     for path in getattr(settings, 'PING_CHECKS', PING_DEFAULT_CHECKS):
@@ -25,7 +26,7 @@ def checks(request):
                 func = getattr(mod, attr)
             except AttributeError:
                 raise ImproperlyConfigured('Module "%s" does not define a "%s" callable' % (module, attr))
-            
+
             key, value = func(request)
             response_dict[key] = value
 
@@ -33,7 +34,7 @@ def checks(request):
 
 #DEFAULT SYSTEM CHECKS
 
-#Database    
+#Database
 def check_database_sessions(request):
     from django.contrib.sessions.models import Session
     try:
@@ -55,7 +56,7 @@ def check_database_sites(request):
 CACHE_KEY = 'django-ping-test'
 CACHE_VALUE = 'abc123'
 
-def check_cache_set(request):        
+def check_cache_set(request):
     from django.core.cache import cache
     try:
         cache.set(CACHE_KEY, CACHE_VALUE, 30)
@@ -63,7 +64,7 @@ def check_cache_set(request):
     except:
         return 'cache_set', False
 
-def check_cache_get(request):        
+def check_cache_get(request):
     from django.core.cache import cache
     try:
         data = cache.get(CACHE_KEY)
@@ -76,7 +77,7 @@ def check_cache_get(request):
 
 
 #User
-def check_user_exists(request):        
+def check_user_exists(request):
     from django.contrib.auth.models import User
     try:
         username = request.GET.get('username')
@@ -95,7 +96,7 @@ def check_celery(request):
     now = time()
     datetimenow = datetime.now()
     expires = datetimenow + timedelta(seconds=getattr(settings, 'PING_CELERY_TIMEOUT', PING_CELERY_TIMEOUT))
-    
+
     try:
         task = sample_task.apply_async(expires=expires)
         while expires > datetime.now():

--- a/ping/urls.py
+++ b/ping/urls.py
@@ -1,7 +1,6 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from ping.views import status
 
 urlpatterns = patterns('',
     url(r'^$', status, name='status'),
 )
-

--- a/ping/views.py
+++ b/ping/views.py
@@ -1,6 +1,7 @@
+import json
+
 from django.http import HttpResponse
 from django.conf import settings
-from django.utils import simplejson
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
 
@@ -14,10 +15,10 @@ def status(request):
     """
     Returns a simple HttpResponse
     """
-        
+
     response = "<h1>%s</h1>" % getattr(settings, 'PING_DEFAULT_RESPONSE', PING_DEFAULT_RESPONSE)
     mimetype = getattr(settings, 'PING_DEFAULT_MIMETYPE', PING_DEFAULT_MIMETYPE)
-    
+
     if request.GET.get('checks') == 'true':
         response_dict = checks(request)
         response += "<dl>"
@@ -28,11 +29,11 @@ def status(request):
 
     if request.GET.get('fmt') == 'json':
         try:
-            response = simplejson.dumps(response_dict)
+            response = json.dumps(response_dict)
         except UnboundLocalError:
             response_dict = checks(request)
-            response = simplejson.dumps(response_dict)
-        response = simplejson.dumps(response_dict, sort_keys=True)
-        mimetype = 'application/json'  
+            response = json.dumps(response_dict)
+        response = json.dumps(response_dict, sort_keys=True)
+        mimetype = 'application/json'
 
     return HttpResponse(response, mimetype=mimetype, status=200)


### PR DESCRIPTION
This pull request combines both of external branches that fix Django 1.9 support.

The `rizmu` branch has the most features, while the `develop` has other fixes.
In turn this hurts Django 1.9 projects: one branch has the `mimetype -> content_type` fix, the other has the `importlib` fix. both are needed for Django 1.9. I've also updated the `urls.py` for Django 1.10
